### PR TITLE
fix: concat body in res.end

### DIFF
--- a/src/main/js/response.js
+++ b/src/main/js/response.js
@@ -93,7 +93,7 @@ export default class Response implements IResponse {
     }
     this.end = (chunk: IData, encoding?: ?string): IResponse => {
       if (chunk) {
-        body = chunk
+        write(chunk, encoding)
       }
       this.emit('finish')
       return this

--- a/src/test/js/response.js
+++ b/src/test/js/response.js
@@ -78,5 +78,13 @@ describe('response', () => {
       res.write()
       expect(res.body).toBe('foobar')
     })
+
+    it('write and end', () => {
+      const res = new Response()
+      res.write('foo')
+      res.write(Buffer.from('bar'))
+      res.end('!')
+      expect(res.body).toBe('foobar!')
+    })
   })
 })


### PR DESCRIPTION
I'm not familiar with flow and am unable to get the tests to run locally as I just get a bunch of "Cannot resolve module lodash" style errors.

However I believe this will demonstrate the issue and fix it!

I have the fix I outlined in #26 working locally.

---

fixes: https://github.com/antongolub/reqresnext/issues/26

- added a test to demonstrate how write and end are used together that should fail with the current code
- use the already bound write method to ensure that body is concatenated correctly
- this seemed like the quickest way to do this, as callback isn't used