### PR TITLE
Added unpipe as a noop to request

### DIFF
--- a/src/main/js/request.js
+++ b/src/main/js/request.js
@@ -18,6 +18,7 @@ import type {
 } from './interface'
 
 import express from 'express'
+import { noop } from 'lodash'
 import url from 'url'
 import {
   assign,
@@ -59,14 +60,17 @@ export default class Request implements IRequest {
 
   _readableState: IAny
 
+  unpipe: Function
+
   socket: ISocket
 
   constructor (input: ?IRawOptions) {
     setprototypeof(this, request)
     const opts = new ReqOptions(input || {})
 
-    this._flush = () => {}
+    this._flush = noop
     this._readableState = {}
+    this.unpipe = noop
     this.socket = opts.socket
     this.app = opts.app
     this.res = opts.res

--- a/src/test/js/express.js
+++ b/src/test/js/express.js
@@ -1,0 +1,39 @@
+import reqresnext from '../../main/js/reqresnext'
+import express from 'express'
+
+describe('express', () => {
+  it('reqresnext correctly 404s when no route handlers are available', (done) => {
+    const { req, res } = reqresnext({
+      method: 'GET',
+      url: '/'
+    })
+
+    const app = express()
+
+    res.on('finish', () => {
+      expect(res.statusCode).toBe(404)
+      done()
+    })
+
+    app(req, res)
+  })
+
+  it('route handler is called when available', (done) => {
+    const { req, res } = reqresnext({
+      method: 'GET',
+      url: '/'
+    }, {})
+
+    const app = express()
+    app.get('/', (_req, _res) => {
+      return _res.sendStatus(200)
+    })
+
+    res.on('finish', () => {
+      expect(res.statusCode).toBe(200)
+      done()
+    })
+
+    app(req, res)
+  })
+})


### PR DESCRIPTION
closes https://github.com/antongolub/reqresnext/issues/29

- this adds a new type of test showing what happens when req and res are used in conjunction with express
- added a noop for unpipe, which fixes the broken test