### PR TITLE
Lowercasing request headers

### DIFF
--- a/src/main/js/request.js
+++ b/src/main/js/request.js
@@ -23,7 +23,8 @@ import url from 'url'
 import {
   assign,
   setprototypeof,
-  appendAdditionalProps
+  appendAdditionalProps,
+  convertKeysToLowerCase
 } from './util'
 import DEFAULT_APP from './app'
 
@@ -74,7 +75,7 @@ export default class Request implements IRequest {
     this.socket = opts.socket
     this.app = opts.app
     this.res = opts.res
-    this.headers = opts.headers
+    this.headers = opts.headers ? convertKeysToLowerCase(opts.headers) : {}
     this.body = opts.body
     this.params = opts.params
     this.connection = opts.connection

--- a/src/main/js/util.js
+++ b/src/main/js/util.js
@@ -18,3 +18,13 @@ export function appendAdditionalProps (target: Object, props: Object): void {
 export function concat (...strings: Array<?string>): string {
   return strings.join('')
 }
+
+export function convertKeysToLowerCase (map: Object): Object {
+  const newMap = {}
+
+  for (const key in map) {
+    newMap[key.toLowerCase()] = map[key]
+  }
+
+  return newMap
+}

--- a/src/test/js/request.js
+++ b/src/test/js/request.js
@@ -47,6 +47,13 @@ describe('request', () => {
         expect(req.header('foo')).toBe('bar')
         expect(req.get('BAZ')).toBe('qux')
       })
+
+      it('lowercases incoming headers', () => {
+        const req = new Request({ headers: { 'BaZ-Header': 'qux' } })
+
+        expect(req.get('Baz-Header')).toBe('qux')
+        expect(req.headers['baz-header']).toBe('qux')
+      })
     })
 
     describe('ip', () => {

--- a/src/test/js/util.js
+++ b/src/test/js/util.js
@@ -1,0 +1,21 @@
+import { convertKeysToLowerCase } from '../../main/js/util'
+
+describe('util', () => {
+  describe('convertKeysToLowerCase', () => {
+    it('converts object keys to lower case keys', () => {
+      const map = {
+        prop: 'value',
+        standard_Notation: 42,
+        'BaZ-Header': 'qux'
+      }
+
+      const lowerCasedMap = convertKeysToLowerCase(map)
+
+      expect(map.standard_Notation).toEqual(42, 'original map is not modified')
+
+      expect(lowerCasedMap.prop).toEqual('value')
+      expect(lowerCasedMap.standard_notation).toEqual(42)
+      expect(lowerCasedMap['baz-header']).toEqual('qux')
+    })
+  })
+})


### PR DESCRIPTION
closes https://github.com/antongolub/reqresnext/issues/33

Note, this only fixes behavior for the request object. The response object should be investigated for similar pattern and maybe fixed too.